### PR TITLE
Implement Cartela da Sorte with FastAPI backend and Flask frontend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Backend
+PORT=8000
+CLUBS_SOURCE_URL=https://en.wikipedia.org/wiki/2024_Campeonato_Brasileiro_S%C3%A9rie_A
+
+# Frontend
+PORT=8080
+BE_BASE_URL=http://localhost:8000
+SECRET_KEY=change-me

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+.env
+.env.*
+venv/
+.venv/

--- a/CartelaDaSorteBE/.env.example
+++ b/CartelaDaSorteBE/.env.example
@@ -1,0 +1,2 @@
+PORT=8000
+CLUBS_SOURCE_URL=https://en.wikipedia.org/wiki/2024_Campeonato_Brasileiro_S%C3%A9rie_A

--- a/CartelaDaSorteBE/Dockerfile
+++ b/CartelaDaSorteBE/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app app
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/CartelaDaSorteBE/app/__init__.py
+++ b/CartelaDaSorteBE/app/__init__.py
@@ -1,0 +1,1 @@
+# Package initializer

--- a/CartelaDaSorteBE/app/clubs_source.py
+++ b/CartelaDaSorteBE/app/clubs_source.py
@@ -1,0 +1,34 @@
+import os
+import requests
+from bs4 import BeautifulSoup
+from typing import List
+
+FALLBACK_CLUBS = [
+    "Athletico-PR", "Atlético-MG", "Bahia", "Botafogo", "Corinthians",
+    "Criciúma", "Cruzeiro", "Cuiabá", "Flamengo", "Fluminense",
+    "Fortaleza", "Grêmio", "Internacional", "Juventude", "Palmeiras",
+    "Red Bull Bragantino", "São Paulo", "Vasco da Gama", "Vitória", "Atlético-GO",
+]
+
+
+def get_clubs(url: str | None) -> List[str]:
+    """Try to fetch list of clubs from URL, otherwise fallback."""
+    if url:
+        try:
+            resp = requests.get(url, timeout=5)
+            resp.raise_for_status()
+            soup = BeautifulSoup(resp.text, "html.parser")
+            table = soup.find("table")
+            clubs = []
+            if table:
+                for row in table.find_all("tr"):
+                    cols = [c.get_text(strip=True) for c in row.find_all("td")]
+                    if cols:
+                        clubs.append(cols[0])
+                    if len(clubs) == 20:
+                        break
+            if len(clubs) == 20:
+                return clubs
+        except Exception:
+            pass
+    return FALLBACK_CLUBS

--- a/CartelaDaSorteBE/app/main.py
+++ b/CartelaDaSorteBE/app/main.py
@@ -1,0 +1,25 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from dotenv import load_dotenv
+import os
+
+from .routers import router
+
+load_dotenv()
+
+app = FastAPI(title="Cartela da Sorte BE")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(router, prefix="/api")
+
+
+@app.get("/")
+async def root():
+    return {"message": "Cartela da Sorte BE"}

--- a/CartelaDaSorteBE/app/models.py
+++ b/CartelaDaSorteBE/app/models.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+@dataclass
+class Cartela:
+    numero_sorteio: str
+    clubes: List[str]
+    apostas: Dict[str, List[str]] = field(default_factory=dict)
+    sorteado: Optional[str] = None

--- a/CartelaDaSorteBE/app/routers.py
+++ b/CartelaDaSorteBE/app/routers.py
@@ -1,0 +1,33 @@
+from fastapi import APIRouter, HTTPException
+from . import services, schemas
+
+router = APIRouter()
+
+
+@router.post("/NovaCartela", response_model=schemas.Cartela)
+async def nova_cartela():
+    return await services.nova_cartela()
+
+
+@router.post("/ApostarNaCartela", response_model=schemas.ApostaResp)
+async def apostar(req: schemas.ApostaReq):
+    try:
+        return await services.apostar(req)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.get("/AtualizarCartela", response_model=schemas.Cartela)
+async def atualizar(numero_sorteio: str):
+    try:
+        return await services.atualizar(numero_sorteio)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.post("/SortearCartela", response_model=schemas.SortearResp)
+async def sortear(req: schemas.AtualizarReq):
+    try:
+        return await services.sortear(req.numero_sorteio)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))

--- a/CartelaDaSorteBE/app/schemas.py
+++ b/CartelaDaSorteBE/app/schemas.py
@@ -1,0 +1,29 @@
+from pydantic import BaseModel, EmailStr
+from typing import Dict, List, Optional
+
+
+class Cartela(BaseModel):
+    numero_sorteio: str
+    clubes: List[str]
+    apostas: Dict[str, List[str]] = {}
+    sorteado: Optional[str] = None
+
+
+class ApostaReq(BaseModel):
+    numero_sorteio: str
+    email: EmailStr
+    time: str
+
+
+class AtualizarReq(BaseModel):
+    numero_sorteio: str
+
+
+class ApostaResp(BaseModel):
+    numero_sorteio: str
+    apostas: Dict[str, List[str]]
+
+
+class SortearResp(BaseModel):
+    numero_sorteio: str
+    time_sorteado: str

--- a/CartelaDaSorteBE/app/services.py
+++ b/CartelaDaSorteBE/app/services.py
@@ -1,0 +1,49 @@
+import os
+import random
+from typing import Dict, List
+
+from . import state, utils, models, schemas, clubs_source
+
+
+async def nova_cartela() -> schemas.Cartela:
+    async with state.lock:
+        url = os.getenv("CLUBS_SOURCE_URL")
+        clubes = clubs_source.get_clubs(url)
+        numero = utils.generate_numero_sorteio()
+        apostas = {club: [] for club in clubes}
+        cartela = models.Cartela(numero_sorteio=numero, clubes=clubes, apostas=apostas)
+        state.cartela_atual = cartela
+        return schemas.Cartela(**cartela.__dict__)
+
+
+async def apostar(req: schemas.ApostaReq) -> schemas.ApostaResp:
+    async with state.lock:
+        cartela = state.cartela_atual
+        if not cartela or cartela.numero_sorteio != req.numero_sorteio:
+            raise ValueError("Número de sorteio inválido")
+        if req.time not in cartela.clubes:
+            raise ValueError("Time inválido")
+        nick = utils.apelido(req.email)
+        nomes = cartela.apostas.setdefault(req.time, [])
+        if nick not in nomes:
+            nomes.append(nick)
+        return schemas.ApostaResp(numero_sorteio=cartela.numero_sorteio, apostas=cartela.apostas)
+
+
+async def atualizar(numero_sorteio: str) -> schemas.Cartela:
+    cartela = state.cartela_atual
+    if not cartela or cartela.numero_sorteio != numero_sorteio:
+        raise ValueError("Número de sorteio inválido")
+    return schemas.Cartela(**cartela.__dict__)
+
+
+async def sortear(numero_sorteio: str) -> schemas.SortearResp:
+    async with state.lock:
+        cartela = state.cartela_atual
+        if not cartela or cartela.numero_sorteio != numero_sorteio:
+            raise ValueError("Número de sorteio inválido")
+        if not all(cartela.apostas[club] for club in cartela.clubes):
+            raise ValueError("Cartela incompleta")
+        if cartela.sorteado is None:
+            cartela.sorteado = random.choice(cartela.clubes)
+        return schemas.SortearResp(numero_sorteio=cartela.numero_sorteio, time_sorteado=cartela.sorteado)

--- a/CartelaDaSorteBE/app/state.py
+++ b/CartelaDaSorteBE/app/state.py
@@ -1,0 +1,6 @@
+import asyncio
+from typing import Optional
+from .models import Cartela
+
+cartela_atual: Optional[Cartela] = None
+lock = asyncio.Lock()

--- a/CartelaDaSorteBE/app/tests/test_api.py
+++ b/CartelaDaSorteBE/app/tests/test_api.py
@@ -1,0 +1,44 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+
+def create_cartela():
+    resp = client.post("/api/NovaCartela")
+    assert resp.status_code == 200
+    return resp.json()
+
+
+def test_nova_cartela_returns_20_clubs():
+    data = create_cartela()
+    assert len(data["clubes"]) == 20
+
+
+def test_apostar_e_atualizar():
+    data = create_cartela()
+    numero = data["numero_sorteio"]
+    clube = data["clubes"][0]
+    resp = client.post("/api/ApostarNaCartela", json={"numero_sorteio": numero, "email": "maria@test.com", "time": clube})
+    assert resp.status_code == 200
+    resp = client.get("/api/AtualizarCartela", params={"numero_sorteio": numero})
+    assert resp.status_code == 200
+    assert resp.json()["apostas"][clube] == ["maria"]
+
+
+def test_sortear_regras():
+    data = create_cartela()
+    numero = data["numero_sorteio"]
+    clubes = data["clubes"]
+    # preenche 19 clubes
+    for idx, clube in enumerate(clubes[:-1]):
+        client.post("/api/ApostarNaCartela", json={"numero_sorteio": numero, "email": f"u{idx}@t.com", "time": clube})
+    # tenta sortear -> erro
+    resp = client.post("/api/SortearCartela", json={"numero_sorteio": numero})
+    assert resp.status_code == 400
+    # preenche ultimo
+    ultimo = clubes[-1]
+    client.post("/api/ApostarNaCartela", json={"numero_sorteio": numero, "email": "u_final@t.com", "time": ultimo})
+    resp = client.post("/api/SortearCartela", json={"numero_sorteio": numero})
+    assert resp.status_code == 200
+    assert resp.json()["time_sorteado"] in clubes

--- a/CartelaDaSorteBE/app/utils.py
+++ b/CartelaDaSorteBE/app/utils.py
@@ -1,0 +1,9 @@
+import uuid
+
+
+def generate_numero_sorteio() -> str:
+    return uuid.uuid4().hex[:8]
+
+
+def apelido(email: str) -> str:
+    return email.split("@")[0]

--- a/CartelaDaSorteBE/requirements.txt
+++ b/CartelaDaSorteBE/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+python-dotenv
+requests
+beautifulsoup4
+pytest

--- a/CartelaDaSorteFE/.env.example
+++ b/CartelaDaSorteFE/.env.example
@@ -1,0 +1,3 @@
+PORT=8080
+BE_BASE_URL=http://localhost:8000
+SECRET_KEY=change-me

--- a/CartelaDaSorteFE/Dockerfile
+++ b/CartelaDaSorteFE/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["flask", "--app", "app.py", "run", "--host", "0.0.0.0", "--port", "8080"]

--- a/CartelaDaSorteFE/app.py
+++ b/CartelaDaSorteFE/app.py
@@ -1,0 +1,108 @@
+import os
+from flask import Flask, render_template, request, redirect, url_for, session, jsonify
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+app = Flask(__name__)
+app.secret_key = os.getenv("SECRET_KEY", "secret")
+BE_BASE_URL = os.getenv("BE_BASE_URL", "http://localhost:8000")
+
+
+def get_apelido(email: str) -> str:
+    return email.split("@")[0]
+
+
+def ensure_cartela():
+    numero = session.get("numero_sorteio")
+    if not numero:
+        resp = requests.post(f"{BE_BASE_URL}/api/NovaCartela")
+        data = resp.json()
+        session["numero_sorteio"] = data["numero_sorteio"]
+    numero = session["numero_sorteio"]
+    resp = requests.get(f"{BE_BASE_URL}/api/AtualizarCartela", params={"numero_sorteio": numero})
+    return resp.json()
+
+
+@app.route("/", methods=["GET"])
+def index():
+    email = session.get("email")
+    if not email:
+        return render_template("index.html", logged=False)
+    cartela = ensure_cartela()
+    return render_template(
+        "index.html",
+        logged=True,
+        apelido=get_apelido(email),
+        cartela=cartela,
+    )
+
+
+@app.post("/login")
+def login():
+    email = request.form.get("email")
+    if not email:
+        return redirect(url_for("index"))
+    session["email"] = email
+    session["apelido"] = get_apelido(email)
+    session.pop("numero_sorteio", None)
+    return redirect(url_for("index"))
+
+
+@app.get("/logout")
+def logout():
+    session.clear()
+    return redirect(url_for("index"))
+
+
+@app.post("/aposta")
+def aposta():
+    if "email" not in session:
+        return "", 401
+    time = request.form.get("time")
+    cartela = ensure_cartela()
+    numero = cartela["numero_sorteio"]
+    requests.post(
+        f"{BE_BASE_URL}/api/ApostarNaCartela",
+        json={"numero_sorteio": numero, "email": session["email"], "time": time},
+    )
+    cartela = ensure_cartela()
+    return render_template("_grid.html", cartela=cartela, apelido=session["apelido"])
+
+
+@app.get("/atualizar")
+def atualizar():
+    if "email" not in session:
+        return "", 401
+    cartela = ensure_cartela()
+    return render_template("_grid.html", cartela=cartela, apelido=session["apelido"])
+
+
+@app.post("/sortear")
+def sortear():
+    if "email" not in session:
+        return "", 401
+    numero = session.get("numero_sorteio")
+    resp = requests.post(f"{BE_BASE_URL}/api/SortearCartela", json={"numero_sorteio": numero})
+    if resp.status_code != 200:
+        return resp.text, resp.status_code
+    data = resp.json()
+    cartela = ensure_cartela()
+    cartela["sorteado"] = data["time_sorteado"]
+    return render_template("_result.html", cartela=cartela)
+
+
+@app.post("/nova")
+def nova():
+    if "email" not in session:
+        return "", 401
+    resp = requests.post(f"{BE_BASE_URL}/api/NovaCartela")
+    data = resp.json()
+    session["numero_sorteio"] = data["numero_sorteio"]
+    cartela = ensure_cartela()
+    return render_template("_grid.html", cartela=cartela, apelido=session["apelido"])
+
+
+if __name__ == "__main__":
+    app.run(port=int(os.getenv("PORT", 8080)), debug=True)

--- a/CartelaDaSorteFE/requirements.txt
+++ b/CartelaDaSorteFE/requirements.txt
@@ -1,0 +1,3 @@
+flask
+python-dotenv
+requests

--- a/CartelaDaSorteFE/static/css/custom.css
+++ b/CartelaDaSorteFE/static/css/custom.css
@@ -1,0 +1,1 @@
+/* Custom styles */

--- a/CartelaDaSorteFE/templates/_cell.html
+++ b/CartelaDaSorteFE/templates/_cell.html
@@ -1,0 +1,9 @@
+<div class="border p-2 bg-white">
+    <form hx-post="{{ url_for('aposta') }}" hx-target="#cartela" hx-swap="outerHTML">
+        <input type="hidden" name="time" value="{{ club }}">
+        <button class="w-full text-left">
+            <div class="font-semibold">{{ club }}</div>
+            <div class="text-sm text-gray-700">{{ ', '.join(apostas) }}</div>
+        </button>
+    </form>
+</div>

--- a/CartelaDaSorteFE/templates/_grid.html
+++ b/CartelaDaSorteFE/templates/_grid.html
@@ -4,11 +4,11 @@
         {% set completa = false %}
     {% endif %}
 {% endfor %}
-<div>
+<div id="cartela" class="space-y-4">
     <div class="font-bold mb-2">Número do Sorteio: {{ cartela.numero_sorteio }}</div>
     <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-2">
     {% for club in cartela.clubes %}
-        <div class="border p-2 bg-white" >
+        <div class="border p-2 bg-white">
             <form hx-post="{{ url_for('aposta') }}" hx-target="#cartela" hx-swap="outerHTML">
                 <input type="hidden" name="time" value="{{ club }}">
                 <button class="w-full text-left">
@@ -24,4 +24,5 @@
         <button hx-post="{{ url_for('sortear') }}" hx-target="#result" hx-swap="outerHTML" class="bg-red-500 text-white px-4 py-2" {% if not completa %}disabled{% endif %}>Sortear</button>
         <button hx-post="{{ url_for('nova') }}" hx-target="#cartela" hx-swap="outerHTML" class="bg-blue-500 text-white px-4 py-2">Nova</button>
     </div>
+    {% include '_result.html' %}
 </div>

--- a/CartelaDaSorteFE/templates/_grid.html
+++ b/CartelaDaSorteFE/templates/_grid.html
@@ -1,0 +1,27 @@
+{% set completa = true %}
+{% for c in cartela.clubes %}
+    {% if not cartela.apostas[c] %}
+        {% set completa = false %}
+    {% endif %}
+{% endfor %}
+<div>
+    <div class="font-bold mb-2">Número do Sorteio: {{ cartela.numero_sorteio }}</div>
+    <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-2">
+    {% for club in cartela.clubes %}
+        <div class="border p-2 bg-white" >
+            <form hx-post="{{ url_for('aposta') }}" hx-target="#cartela" hx-swap="outerHTML">
+                <input type="hidden" name="time" value="{{ club }}">
+                <button class="w-full text-left">
+                    <div class="font-semibold">{{ club }}</div>
+                    <div class="text-sm text-gray-700">{{ ', '.join(cartela.apostas[club]) }}</div>
+                </button>
+            </form>
+        </div>
+    {% endfor %}
+    </div>
+    <div class="mt-4 flex space-x-2">
+        <button hx-get="{{ url_for('atualizar') }}" hx-target="#cartela" hx-swap="outerHTML" class="bg-gray-300 px-4 py-2">Atualizar</button>
+        <button hx-post="{{ url_for('sortear') }}" hx-target="#result" hx-swap="outerHTML" class="bg-red-500 text-white px-4 py-2" {% if not completa %}disabled{% endif %}>Sortear</button>
+        <button hx-post="{{ url_for('nova') }}" hx-target="#cartela" hx-swap="outerHTML" class="bg-blue-500 text-white px-4 py-2">Nova</button>
+    </div>
+</div>

--- a/CartelaDaSorteFE/templates/_result.html
+++ b/CartelaDaSorteFE/templates/_result.html
@@ -1,0 +1,5 @@
+<div id="result" class="mt-4 text-xl font-bold">
+{% if cartela.sorteado %}
+    Time Sorteado: {{ cartela.sorteado }}
+{% endif %}
+</div>

--- a/CartelaDaSorteFE/templates/base.html
+++ b/CartelaDaSorteFE/templates/base.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cartela da Sorte</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}">
+</head>
+<body class="bg-gray-100">
+    <div class="max-w-4xl mx-auto p-4">
+        {% block content %}{% endblock %}
+    </div>
+</body>
+</html>

--- a/CartelaDaSorteFE/templates/index.html
+++ b/CartelaDaSorteFE/templates/index.html
@@ -7,10 +7,7 @@
 </form>
 {% else %}
 <div class="mb-4">Olá {{ apelido }}, clique em apenas um time abaixo:</div>
-<div id="cartela" class="space-y-4">
-    {% include '_grid.html' %}
-    {% include '_result.html' %}
-</div>
+{% include '_grid.html' %}
 <div class="mt-4">
     <a href="{{ url_for('logout') }}" class="text-sm text-blue-500">Sair</a>
 </div>

--- a/CartelaDaSorteFE/templates/index.html
+++ b/CartelaDaSorteFE/templates/index.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+{% block content %}
+{% if not logged %}
+<form method="post" action="{{ url_for('login') }}" class="space-y-4">
+    <input type="email" name="email" required class="border p-2 w-full" placeholder="seu email">
+    <button class="bg-blue-500 text-white px-4 py-2">Entrar</button>
+</form>
+{% else %}
+<div class="mb-4">Olá {{ apelido }}, clique em apenas um time abaixo:</div>
+<div id="cartela" class="space-y-4">
+    {% include '_grid.html' %}
+    {% include '_result.html' %}
+</div>
+<div class="mt-4">
+    <a href="{{ url_for('logout') }}" class="text-sm text-blue-500">Sair</a>
+</div>
+{% endif %}
+{% endblock %}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
-# carteladasorteapp
+# Cartela da Sorte
+
+Aplicação completa com **FastAPI** no back-end e **Flask** no front-end usando **HTMX** e **TailwindCSS**.
+
+## Estrutura
+
+- `CartelaDaSorteBE/` – API FastAPI
+- `CartelaDaSorteFE/` – Front-end Flask
+- `docker-compose.yml` – Executa BE e FE juntos
+
+## Configuração
+
+1. Copie os arquivos `.env.example` para `.env` nas pastas raiz, `CartelaDaSorteBE/` e `CartelaDaSorteFE/` conforme necessário.
+2. Ajuste variáveis se desejar.
+
+## Rodando sem Docker
+
+### Back-end
+```bash
+cd CartelaDaSorteBE
+uvicorn app.main:app --reload --port 8000
+```
+
+### Front-end
+```bash
+cd CartelaDaSorteFE
+flask --app app.py run --port 8080
+```
+
+## Rodando com Docker
+
+```bash
+docker compose up --build
+```
+
+## Testes
+
+```bash
+cd CartelaDaSorteBE
+pytest
+```
+
+## Notas
+
+- A lista de clubes é buscada online; se falhar, usa-se um conjunto local de 20 times da Série A.
+- Os dados da cartela são mantidos apenas em memória; reiniciar o back-end limpa as apostas.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.9'
+services:
+  be:
+    build: ./CartelaDaSorteBE
+    ports:
+      - "8000:8000"
+    env_file:
+      - ./CartelaDaSorteBE/.env.example
+  fe:
+    build: ./CartelaDaSorteFE
+    ports:
+      - "8080:8080"
+    depends_on:
+      - be
+    env_file:
+      - ./CartelaDaSorteFE/.env.example
+    environment:
+      - BE_BASE_URL=http://be:8000


### PR DESCRIPTION
## Summary
- remove embedded image banner and stray compiled test artifact
- drop image tag from base template and update README accordingly
- add gitignore to keep binary caches out of version control

## Testing
- `python -m pip install -r CartelaDaSorteBE/requirements.txt` *(failed: Could not find a version that satisfies the requirement fastapi (from versions: none))*
- `cd CartelaDaSorteBE && pytest` *(failed: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68ae342243d4832092685ba095a456aa